### PR TITLE
Allow events to be directly linked to with a fragment

### DIFF
--- a/rides/templates/index.html
+++ b/rides/templates/index.html
@@ -6,9 +6,12 @@
       {% for event in events %}
         <div class="card mb-3">
         {% if events|length != 1 %}
-          <h3 class="card-header" align="center"><a data-toggle="collapse" href="#event{{ event.id }}"
-                                                    style="color: inherit; text-decoration: none;">{{ event.name }}</a>
-          </h3>
+          <a data-toggle="collapse" href="#event{{ event.id }}"
+             id="opener-event{{ event.id }}"
+             class="card-opener"
+             style="color: inherit; text-decoration: none;">
+            <h3 class="card-header" align="center">{{ event.name }}</h3>
+          </a>
           <div class="collapse" id="event{{ event.id }}">
           <div class="card-body">
         {% else %}

--- a/rides/templates/layout.html
+++ b/rides/templates/layout.html
@@ -77,6 +77,18 @@
       ({{commit}})</a></p>
   </div>
 </footer>
+<script>
+  // Allow linking directly to events
+  $("a.card-opener").click(function() {
+    // Add our location, since toggle library preventDefault's for some reason...
+    location.href = $(this).attr("href");
+  });
+  var eventId = location.hash.substring(1);
+  var opener = document.getElementById("opener-" + eventId);
+  if (opener) {
+    opener.click();
+  }
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
Rides can be linked to directly, which should be helpful when making posts in announcements
![image](https://user-images.githubusercontent.com/6877780/135653345-241be481-5ad1-4ae1-844e-686de35e8e3d.png)
(Notice the URL fragment, neat!)

Also coincidentally fixes some weirdness with the size of the touch target on ride cards (the touch target now extends through the entire event name area, not just the text)